### PR TITLE
add CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+on:
+  push:
+    tags:
+    - 'v*'
+
+name: Create Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: save upload url
+        run: echo '${{ steps.create_release.outputs.upload_url }}' > upload-url
+
+      - name: upload the upload url
+        uses: actions/upload-artifact@v2
+        with:
+          name: upload-url
+          path: upload-url
+
+  build_ubuntu:
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+    - name: download the upload-url artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: upload-url
+    
+    - name: save download url
+      id : save-download-url
+      run: |
+        echo ::set-output name=UPLOAD_URL::"$(cat upload-url)"
+    
+    - uses: actions/checkout@v2
+    - name: build ubuntu for release
+      run: cargo build --verbose --release
+    
+    - name: Upload Release Asset Linux
+      id: upload-release-asset-linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
+        asset_path: target/release/ssologin
+        asset_name: ssologin_ubuntu
+        asset_content_type: application/octet-stream
+
+  build_windows:
+    runs-on: windows-latest
+    needs: [release]
+    steps:
+    - name: download the upload-url artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: upload-url
+    
+    - name: save download url
+      id : save-download-url
+      run: |
+        $output=(type upload-url)
+        Write-Output "::set-output name=UPLOAD_URL::$output"
+    
+    - uses: actions/checkout@v2
+    - name: build windows for release
+      run: cargo build --verbose --release
+    
+    - name: Upload Release Asset windows
+      id: upload-release-asset-windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
+        asset_path: target/release/ssologin.exe
+        asset_name: ssologin.exe
+        asset_content_type: application/octet-stream
+
+  build_mac:
+    runs-on: macos-latest
+    needs: [release]
+    steps:
+    - name: download the upload-url artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: upload-url
+    
+    - name: save download url
+      id : save-download-url
+      run: |
+        echo ::set-output name=UPLOAD_URL::"$(cat upload-url)"
+    
+    - uses: actions/checkout@v2
+    - name: build mac for release
+      run: cargo build --verbose --release
+    
+    - name: Upload Release Asset Mac
+      id: upload-release-asset-mac
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
+        asset_path: target/release/ssologin
+        asset_name: ssologin_mac
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This adds CI/CD to the GitHub workflow. 

The action creates a new release when a new tag is created. `git tag vX.X.X && git push --tags`.
The action then builds the three release assets (`ssologin_ubuntu`, `ssologin.exe`, and `ssologin_mac`), and uploads these assets to the release. 

It is up to the maintainer to edit the release write up. 

The initial CI test remains in the repo, so that each commit to master will still create a build for each of the above. 

**TODO**: Update ubuntu with musl build. 