### PR TITLE
update install script to accept any install path, not just default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Using AWS SSO with tools like terraform require you to go to the AWS SSO start u
 
 This tool skips all that fuss, set up your AWS SSO like you normally would (`aws sso configure`). And then just run
 
-```
-ssologin -p <aws_profile> 
+```shell
+$ ssologin -p <aws_profile> 
 ```
 
 and it will save the credentials to your AWS credentials file directly.
@@ -15,5 +15,16 @@ and it will save the credentials to your AWS credentials file directly.
 Run the below command to download and run the installer: 
 
 ```shell
-$ curl -LJ https://raw.githubusercontent.com/thehamsterjam/master/install/linux_install.sh | bash
+$ wget https://raw.githubusercontent.com/thehamsterjam/better_aws_sso/master/install/linux_install.sh | bash
+```
+
+The installer installs to a default location `/usr/local/bin`. To change this, instead download the installer, and pass the desired path in. This path is preserved with all updates. 
+
+```shell
+$ wget https://raw.githubusercontent.com/thehamsterjam/better_aws_sso/master/install/linux_install.sh
+```
+
+```shell
+$ chmod +x ./linux_install.sh
+$ ./linux_install.sh -p <desired_path>
 ```

--- a/install/linux_install.sh
+++ b/install/linux_install.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -e 
 
+## VARIABLES
+INSTALL_DIR="/usr/local/bin"
+
+
+## CHECK OPTIONS
+while getopts ":p:" opt; do
+  case $opt in
+    p) INSTALL_DIR="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+INSTALL_DIR="$INSTALL_DIR/ssologin" ## Append ssologin to the end of path. 
+
 main(){
 	echo ":::"
 
@@ -23,9 +38,9 @@ main(){
 	LATEST_RELEASE=$(curl --silent "https://api.github.com/repos/thehamsterjam/better_aws_sso/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
 	# echo "::: Will install version $LATEST_RELEASE"
 
-	if [[ -f /usr/local/bin/ssologin ]]; then
+	if command -v ssologin &> /dev/null; then
 		echo "::: ssologin exists on your filesystem, considering upgrading..."
-
+		INSTALLED_DIR=$(command -v ssologin)
 		INSTALLED_VERSION=$(ssologin -V)
 		temp=$(echo $INSTALLED_VERSION)
 		INSTALLED_VERSION=(${temp//[\(\),]/})
@@ -44,7 +59,8 @@ main(){
 	
 	echo "::: I require your password for chmod and install"
 	$SUDO chmod +x ssologin_ubuntu
-	$SUDO mv ssologin_ubuntu /usr/local/bin/ssologin
+	echo "::: Installation directory is $INSTALL_DIR"
+	$SUDO mv ssologin_ubuntu $INSTALL_DIR
 	ssologin --help
 	echo "::: Done"
 }


### PR DESCRIPTION
This PR Corrects the issues in #4 

It retains the install path for ssologin, and allows a user to set a new install path. 

Documentation has also been updated. 