### PR TITLE
correct linux artifact name

### DIFF
--- a/install/linux_install.sh
+++ b/install/linux_install.sh
@@ -55,12 +55,12 @@ main(){
 	fi
 
 	echo "::: Will install version $LATEST_RELEASE"
-	wget -q --show-progress https://github.com/thehamsterjam/better_aws_sso/releases/download/$LATEST_RELEASE/ssologin_ubuntu
+	wget -q --show-progress https://github.com/thehamsterjam/better_aws_sso/releases/download/$LATEST_RELEASE/ssologin_linux
 	
 	echo "::: I require your password for chmod and install"
-	$SUDO chmod +x ssologin_ubuntu
+	$SUDO chmod +x ssologin_linux
 	echo "::: Installation directory is $INSTALL_DIR"
-	$SUDO mv ssologin_ubuntu $INSTALL_DIR
+	$SUDO mv ssologin_linux $INSTALL_DIR
 	ssologin --help
 	echo "::: Done"
 }


### PR DESCRIPTION
There is a bug in the installer that points to artifacts with the name `ssologin_ubuntu`. This has been corrected to `ssologin_linux`. 

This is a repeat of PR #7, which was accidentally closed by fat fingers in the forked repo. 