### PR TITLE
add ignore paths to rust action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,17 +3,25 @@ name: Rust
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+    - 'README.md'
+    - 'LICENSE'
+    - '/install'
+    - '.gitignore'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+    - 'README.md'
+    - 'LICENSE'
+    - '/install'
+    - '.gitignore'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build static


### PR DESCRIPTION
This will stop the rust action from creating new build on pull requests and pushes if there are no changes to the source code. 