### PR TITLE
feat: update to handle both old and new aws config formats

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,115 +6,46 @@ on:
 name: Create Release
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: save upload url
-        run: echo '${{ steps.create_release.outputs.upload_url }}' > upload-url
-
-      - name: upload the upload url
-        uses: actions/upload-artifact@v2
-        with:
-          name: upload-url
-          path: upload-url
-
   build_linux:
     runs-on: ubuntu-latest
-    needs: [release]
     steps:
-    - name: download the upload-url artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: upload-url
-    
-    - name: save download url
-      id : save-download-url
-      run: |
-        echo ::set-output name=UPLOAD_URL::"$(cat upload-url)"
-    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build static
       uses:  stevenleadbeater/rust-musl-builder@master
       with:
-          args: /bin/bash -c "cargo build --release --target=x86_64-unknown-linux-musl" 
-    
-    - name: Upload Release Asset Linux
-      id: upload-release-asset-linux
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: /bin/bash -c "cargo build --release --target=x86_64-unknown-linux-musl"
+
+    - name: Stage asset
+      run: cp target/x86_64-unknown-linux-musl/release/ssologin ssologin_linux
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
       with:
-        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
-        asset_path: target/x86_64-unknown-linux-musl/release/ssologin
-        asset_name: ssologin_linux
-        asset_content_type: application/octet-stream
+        files: ssologin_linux
 
   build_windows:
     runs-on: windows-latest
-    needs: [release]
     steps:
-    - name: download the upload-url artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: upload-url
-    
-    - name: save download url
-      id : save-download-url
-      run: |
-        $output=(type upload-url)
-        Write-Output "::set-output name=UPLOAD_URL::$output"
-    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build windows for release
       run: cargo build --verbose --release
-    
-    - name: Upload Release Asset windows
-      id: upload-release-asset-windows
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
       with:
-        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
-        asset_path: target/release/ssologin.exe
-        asset_name: ssologin.exe
-        asset_content_type: application/octet-stream
+        files: target/release/ssologin.exe
 
   build_mac:
     runs-on: macos-latest
-    needs: [release]
     steps:
-    - name: download the upload-url artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: upload-url
-    
-    - name: save download url
-      id : save-download-url
-      run: |
-        echo ::set-output name=UPLOAD_URL::"$(cat upload-url)"
-    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build mac for release
       run: cargo build --verbose --release
-    
-    - name: Upload Release Asset Mac
-      id: upload-release-asset-mac
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Stage asset
+      run: cp target/release/ssologin ssologin_mac
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
       with:
-        upload_url: ${{ steps.save-download-url.outputs.UPLOAD_URL }}
-        asset_path: target/release/ssologin
-        asset_name: ssologin_mac
-        asset_content_type: application/octet-stream
+        files: ssologin_mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install musl toolchain
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+        rustup target add x86_64-unknown-linux-musl
     - name: Build static
-      uses:  stevenleadbeater/rust-musl-builder@master
-      with:
-          args: /bin/bash -c "cargo build --release --target=x86_64-unknown-linux-musl"
+      run: cargo build --release --target=x86_64-unknown-linux-musl
 
     - name: Stage asset
       run: cp target/x86_64-unknown-linux-musl/release/ssologin ssologin_linux

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build ssologin
 
 on:
   push:
@@ -25,12 +25,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build static
       uses:  stevenleadbeater/rust-musl-builder@master
       with:
           args: /bin/bash -c "cargo build --release --target=x86_64-unknown-linux-musl"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ssologin_ubuntu
         path: target/x86_64-unknown-linux-musl/release/ssologin
@@ -38,10 +38,10 @@ jobs:
   build_win:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose --release
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ssologin.exe
         path: target/release/ssologin.exe
@@ -50,10 +50,10 @@ jobs:
   build_mac:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose --release
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ssologin_mac
         path: target/release/ssologin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,10 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install musl toolchain
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+        rustup target add x86_64-unknown-linux-musl
     - name: Build static
-      uses:  stevenleadbeater/rust-musl-builder@master
-      with:
-          args: /bin/bash -c "cargo build --release --target=x86_64-unknown-linux-musl"
+      run: cargo build --release --target=x86_64-unknown-linux-musl
     - uses: actions/upload-artifact@v4
       with:
         name: ssologin_ubuntu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Rust CLI (`ssologin`) that performs AWS SSO login and writes the resulting temporary credentials directly into `~/.aws/credentials`, bypassing the manual copy-paste flow from the AWS SSO portal. Supports both legacy (`[profile]` with inline `sso_start_url`) and new (`[profile]` + `[sso-session X]`) AWS config formats via two explicit CLI routes.
+
+## Commands
+
+- Build: `cargo build` (debug), `cargo build --release` (used in CI).
+- Static Linux build (matches release artifact): `cargo build --release --target=x86_64-unknown-linux-musl` inside `stevenleadbeater/rust-musl-builder` container.
+- Run (old format): `cargo run -- -p <aws_profile> [-a] [-s] [-v]`.
+- Run (new format): `cargo run -- --sso-session <session> [-p <profile>] [-s] [-v]`.
+- No test suite; `cargo test` is a no-op.
+- Lint/format: standard `cargo fmt`, `cargo clippy` (not enforced in CI).
+
+## CLI routes
+
+`--profile` and `--sso-session` are mutually requiring (one of the two must be set) — clap enforces with `required_unless`.
+
+| Invocation | Format | Behavior |
+|---|---|---|
+| `-p X` | old | reads `[X]` with inline `sso_start_url`/`sso_region`. Runs internal OIDC device-grant flow. |
+| `-p X -a` | old | also picks up every other `[Y]` whose `sso_start_url` matches X's. |
+| `--sso-session Y` | new | reads `[sso-session Y]` for start URL/region. Shells `aws sso login --sso-session Y`. Writes creds for every `[profile *]` whose `sso_session = Y`. |
+| `--sso-session Y -p X` | new | as above but filters to single profile `[profile X]`. |
+
+`-a` is ignored in the `--sso-session` route (multi-profile is the default there).
+
+## Build script side-effect
+
+`build.rs` runs every build and performs a network call to `https://api.github.com/repos/thehamsterjam/better_aws_sso/releases/latest`, then writes the tag name to `src/version`. `src/main.rs` consumes it via `include_str!("version")` to set the clap `--version` string. Consequences:
+- Offline builds fail unless `src/version` already exists.
+- `src/version` is generated; do not hand-edit. (Not in `.gitignore` — check before committing.)
+- Forks pointing at a different repo must update the URL in `build.rs`.
+
+## Runtime architecture (`src/main.rs`, single file)
+
+`main()` branches on `--sso-session` vs `--profile`:
+
+**Old-format flow** (`get_sso_profiles_old` + internal OIDC):
+1. `get_sso_profiles_old` parses `~/.aws/config` via `rust-ini`. With `-a`, iterates every section but skips ones starting with `sso-session ` or `profile ` (would otherwise blow up on a mixed-format config) and requires all four `sso_*` keys inline.
+2. `register_client` → POST `https://oidc.<region>.amazonaws.com/client/register` to get an OIDC client id/secret.
+3. `device_auth` → POST `/device_authorization` to get `verificationUriComplete` + `deviceCode`.
+4. `create_token` opens the verification URL in the user's browser (`webbrowser` crate), then polls `/token` once per second until the user completes auth (loop has no timeout — exits only on success).
+
+**New-format flow** (`get_sso_profiles_new` + `aws` shell-out):
+1. `get_sso_profiles_new` reads `[sso-session <name>]` for start URL/region and collects every `[profile *]` whose `sso_session` key equals `<name>`. Optional single-profile filter via `-p`.
+2. `run_aws_sso_login` shells out: `aws sso login --sso-session <name>`. AWS CLI handles the browser flow and writes a token to `~/.aws/sso/cache/<sha1>.json`. Panics if `aws` isn't on PATH or exits non-zero.
+3. `read_sso_cache_token` scans `~/.aws/sso/cache/*.json`, returns the `accessToken` from the file whose `startUrl` matches. Match is exact-string (no normalization of trailing slashes).
+
+**Shared tail** — for each profile: `get_role_credentials` → GET `https://portal.sso.<region>.amazonaws.com/federation/credentials` with `x-amz-sso_bearer_token`, then `save_sso` writes `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token` into `~/.aws/credentials`.
+
+Per-profile failures (non-2xx from the portal, e.g. role not assigned to that account) are logged and skipped — the loop continues. Other failures still panic via `.unwrap()`.
+
+Credential section name in `~/.aws/credentials`:
+- Default: `<sso_account_id>_<sso_role_name>`.
+- With `-s` / `--save_as_profile_name`: `<profile>_` (trailing underscore intentional, matches existing behavior).
+
+HTTP is `ureq` 1.5 (blocking, sync). JSON via `serde` derive on the response structs at the top of `main.rs`; field names are camelCase to match the AWS API (hence the `#[allow(non_snake_case)]`). Response structs hold only fields actually read by the code — serde drops unknown JSON keys by default.
+
+## Editing notes
+
+- All logic lives in `src/main.rs`. No module split.
+- Errors mostly use `.unwrap()` — failures panic. The one intentional exception is `get_role_credentials`, which returns `Option<GetRoleCredsResponse>` so a single bad profile (e.g. role not assigned) doesn't abort the whole `-a` / `--sso-session` run. Preserve the panic style elsewhere unless a change requires otherwise.
+- The token-polling loop in `create_token` (old-format flow only) does not honor `expiresIn` or `interval` from the device-auth response; it hardcodes 1s. Mention this if touching that function.
+- `_list_accounts` is dead code retained for reference (leading underscore suppresses warning).
+- `old_format.config` and `new_format.config` at the repo root are test fixtures the user swaps into `~/.aws/config` to exercise each route — not loaded automatically.
+
+## Release / install
+
+- `.github/workflows/release.yml` cuts releases; `rust.yml` builds Linux (musl static), Windows, and macOS artifacts on push/PR to `master`.
+- `install/linux_install.sh` downloads the latest release artifact to `/usr/local/bin` by default (`-p <path>` overrides). The installer is what the README's `curl | bash` invocation runs.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,44 @@
 [![Rust](https://github.com/thehamsterjam/better_aws_sso/workflows/Rust/badge.svg)](https://github.com/thehamsterjam/better_aws_sso/actions?query=workflow%3ARust)
 # (Slightly) better AWS sso login
 
-Using AWS SSO with tools like terraform require you to go to the AWS SSO start url, click the account you want, click command line access, copy the text there and then save it to your AWS credentials file. 
+Using AWS SSO with tools like terraform require you to go to the AWS SSO start url, click the account you want, click command line access, copy the text there and then save it to your AWS credentials file.
 
-This tool skips all that fuss, set up your AWS SSO like you normally would (`aws sso configure`) ([more info](#Configuring-AWS-SSO-for-AWS-CLI)). And then just run
+This tool skips all that fuss, set up your AWS SSO like you normally would (`aws sso configure`) ([more info](#Configuring-AWS-SSO-for-AWS-CLI)).
+
+### Old config format
+
+If your `~/.aws/config` uses the original inline format (`[my-dev-profile]` with `sso_start_url = ...` directly inside it), run:
 
 ```shell
-$ ssologin -p <aws_profile> 
+$ ssologin -p <aws_profile>
 ```
 
-and it will save the credentials to your AWS credentials file directly.
-
-There is an extended mode, which will collect all your credentials from a single start URL (meaning that you run `ssologin` once, and authenticate once in your browser). Use the `-a` flag. 
+Extended mode authenticates once and collects creds for every profile sharing the same `sso_start_url`:
 
 ```shell
 $ ssologin -p <aws_profile> -a
 ```
+
+### New config format (sso-session)
+
+If your `~/.aws/config` uses the newer format introduced by `aws configure sso` — `[profile X]` sections referencing a shared `[sso-session Y]` — pass the session name:
+
+```shell
+$ ssologin --sso-session <session_name>
+```
+
+This shells out to `aws sso login --sso-session <session_name>` for the browser auth, then writes credentials for **every** `[profile *]` whose `sso_session = <session_name>`. Filter to a single profile with `-p`:
+
+```shell
+$ ssologin --sso-session <session_name> -p <aws_profile>
+```
+
+Requires the AWS CLI v2 on `PATH`.
+
+### Other flags
+
+- `-s` / `--save_as_profile_name` — save credentials under `[<profile>_]` instead of the default `[<account_id>_<role_name>]`.
+- `-v` / `--verbose` — print HTTP responses and cache lookups.
 
 ## Installation
 
@@ -49,7 +72,9 @@ Please download the [latest release](https://github.com/thehamsterjam/better_aws
 
 ## Configuring AWS SSO for AWS CLI
 
-Configure your [AWS CLI config file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html), which is usually located at `~/.aws/config`, with the below snippet, filling in the fields with your specific information: 
+Configure your [AWS CLI config file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html), which is usually located at `~/.aws/config`. Either format is supported.
+
+**Old (inline) format** — use `ssologin -p my-dev-profile`:
 
 ```
 [my-dev-profile]
@@ -61,7 +86,23 @@ region         = us-west-2
 output         = json
 ```
 
-Then run `ssologin -p my-dev-profile`. This will add credentials to your `~/.aws/credentials` file in the following form:
+**New (sso-session) format** — use `ssologin --sso-session my-org`:
+
+```
+[sso-session my-org]
+sso_region              = us-east-1
+sso_start_url           = https://my-sso-portal.awsapps.com/start
+sso_registration_scopes = sso:account:access
+
+[profile my-dev-profile]
+sso_session    = my-org
+sso_account_id = 123456789011
+sso_role_name  = readOnly
+region         = us-west-2
+output         = json
+```
+
+Either way, credentials end up in `~/.aws/credentials` under a section named `<account_id>_<role_name>`:
 
 ```
 [123456789011_readOnly]
@@ -69,3 +110,11 @@ aws_access_key_id=ASIAXYZ0123456789ABC
 aws_secret_access_key=xyzABC123456789defGHIjklMN/xyzABC1234567
 aws_session_token=XYZ
 ```
+
+## Development
+
+To build and test locally, clone the repo and run `cargo build` and `cargo run -- -p <aws_profile>`. 
+
+## Contributing
+
+Contributions are very welcome! Please open an issue or a PR if you have any suggestions or improvements.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use clap::{App, Arg};
 use ini::Ini;
 use serde::Deserialize;
-use std::{thread, time};
+use std::process::Command;
+use std::{fs, thread, time};
 use ureq::Response;
 use webbrowser;
 extern crate dirs;
@@ -16,7 +17,7 @@ struct SsoProfile {
     sso_start_url: String,
     sso_region : String,
     sso_account_id : String,
-    sso_role_name : String
+    sso_role_name : String,
 }
 
 impl SsoProfile {
@@ -31,30 +32,30 @@ impl SsoProfile {
                 sso_start_url,
                 sso_region,
                 sso_account_id,
-                sso_role_name
+                sso_role_name,
             }
         }
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(non_snake_case)]
+struct SsoCacheToken {
+    startUrl: Option<String>,
+    accessToken: Option<String>,
+    expiresAt: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
 struct RegisterClientResponse {
     clientId: String,
-    clientIdIssuedAt: i32,
     clientSecret: String,
-    clientSecretExpiresAt: i32,
-    authorizationEndpoint: Option<String>,
-    tokenEndpoint: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(non_snake_case)]
 struct StartDeviceAuthorizationResponse {
     deviceCode: String,
-    expiresIn: i32,
-    interval: i32,
-    userCode: String,
-    verificationUri: Option<String>,
     verificationUriComplete: String,
 }
 
@@ -62,17 +63,12 @@ struct StartDeviceAuthorizationResponse {
 #[allow(non_snake_case)]
 struct CreateTokenResponse {
     accessToken: String,
-    expiresIn: i32,
-    idToken: Option<String>,
-    refreshToken: Option<String>,
-    tokenType: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(non_snake_case)]
 struct RoleCreds {
     accessKeyId: String,
-    expiration: i64,
     secretAccessKey: String,
     sessionToken: String,
 }
@@ -94,51 +90,65 @@ fn main() {
                         .short("p")
                         .long("profile")
                         .takes_value(true)
-                        .required(true)
-                        .help("AWS profile set up for SSO"))
+                        .required_unless("sso_session")
+                        .help("AWS profile set up for SSO (old config format). With --sso-session, filters to a single profile under that session."))
+                    .arg(Arg::with_name("sso_session")
+                        .long("sso-session")
+                        .takes_value(true)
+                        .required_unless("profile")
+                        .help("AWS SSO session name (new config format with [sso-session X]). Runs `aws sso login --sso-session X` and writes creds for every [profile *] under it."))
                     .arg(Arg::with_name("save_as_profile_name")
                         .short("s")
                         .long("save_as_profile_name")
-                        .help("Whether to save the credentials under the profile name with an _ at the end or under <account_id>_<role_name>"))
+                        .help("Save credentials under <profile>_ instead of <account_id>_<role_name>"))
                     .arg(Arg::with_name("all")
                         .short("a")
                         .long("all")
-                        .help("Get credentials for all profiles with the same start url as the specified profile"))
+                        .help("With --profile (old format): collect all profiles sharing the same sso_start_url. Ignored with --sso-session."))
                     .arg(Arg::with_name("verbose")
                         .short("v")
                         .long("verbose")
                         .help("Print verbose logging"))
                     .get_matches();
 
-    let profile = matches.value_of("profile").unwrap().to_owned();
     let verbose = matches.is_present("verbose");
     let save_as_profile_name = matches.is_present("save_as_profile_name");
-    let all = matches.is_present("all");
 
     let home = dirs::home_dir().unwrap().to_str().unwrap().to_owned();
-        
-    let sso_profiles = get_sso_profiles(profile, &home,  all);
 
-    let oidc_url = format!("https://oidc.{}.amazonaws.com", sso_profiles[0].sso_region);
+    let (sso_profiles, access_token) = if let Some(session) = matches.value_of("sso_session") {
+        let filter = matches.value_of("profile");
+        let profiles = get_sso_profiles_new(session, &home, filter);
+        run_aws_sso_login(session, verbose);
+        let token = read_sso_cache_token(&profiles[0].sso_start_url, &home, verbose);
+        (profiles, token)
+    } else {
+        let profile = matches.value_of("profile").unwrap().to_owned();
+        let all = matches.is_present("all");
+        let profiles = get_sso_profiles_old(profile, &home, all);
+        let oidc_url = format!("https://oidc.{}.amazonaws.com", profiles[0].sso_region);
+        let register_client_resp = register_client(&oidc_url, verbose);
+        let device_auth_resp = device_auth(&oidc_url, &profiles[0].sso_start_url, &register_client_resp, verbose);
+        let create_token_resp =
+            create_token(&oidc_url, &register_client_resp, &device_auth_resp, verbose);
+        (profiles, create_token_resp.accessToken)
+    };
+
     let sso_url = format!("https://portal.sso.{}.amazonaws.com", sso_profiles[0].sso_region);
-
-    let register_client_resp = register_client(&oidc_url, verbose);
-
-    let device_auth_resp = device_auth(&oidc_url, &sso_profiles[0].sso_start_url, &register_client_resp, verbose);
-
-    let create_token_resp =
-        create_token(&oidc_url, &register_client_resp, &device_auth_resp, verbose);
 
     for sso_profile in sso_profiles {
 
-        let get_role_creds_resp = get_role_credentials(
+        let get_role_creds_resp = match get_role_credentials(
             &sso_url,
             &sso_profile.sso_account_id,
             &sso_profile.sso_role_name,
-            &create_token_resp,
+            &access_token,
             verbose,
-        );
-    
+        ) {
+            Some(r) => r,
+            None => continue,
+        };
+
         save_sso(
             &sso_profile.sso_profile_name,
             &sso_profile.sso_account_id,
@@ -151,46 +161,151 @@ fn main() {
     }
 }
 
-fn get_sso_profiles(profile_name : String, home : &String, all : bool) -> Vec<SsoProfile> {
+fn get_sso_profiles_old(profile_name : String, home : &String, all : bool) -> Vec<SsoProfile> {
 
     let aws_conf = Ini::load_from_file(format!("{}{}", home, "/.aws/config")).unwrap();
 
     let sso_start_url = aws_conf
-        .get_from(Some(format!("{}", profile_name)), "sso_start_url")
-        .unwrap().to_owned();
+        .get_from(Some(profile_name.as_str()), "sso_start_url")
+        .unwrap_or_else(|| panic!("Profile [{}] missing sso_start_url in ~/.aws/config (old format expected; new-format sessions need --sso-session)", profile_name))
+        .to_owned();
     let sso_region = aws_conf
-        .get_from(Some(format!("{}", profile_name)), "sso_region")
+        .get_from(Some(profile_name.as_str()), "sso_region")
         .unwrap().to_owned();
     let sso_account_id = aws_conf
-        .get_from(Some(format!("{}", profile_name)), "sso_account_id")
+        .get_from(Some(profile_name.as_str()), "sso_account_id")
         .unwrap().to_owned();
     let sso_role_name = aws_conf
-        .get_from(Some(format!("{}", profile_name)), "sso_role_name")
+        .get_from(Some(profile_name.as_str()), "sso_role_name")
         .unwrap().to_owned();
 
     if !all {
-        return vec![SsoProfile::new(profile_name, sso_start_url, sso_region, sso_account_id, sso_role_name)]
+        return vec![SsoProfile::new(profile_name, sso_start_url, sso_region, sso_account_id, sso_role_name)];
     }
-    else {
-        let mut profiles = Vec::new();
 
-        for (section, properties) in aws_conf.iter() {
-            if properties.contains_key("sso_start_url") {
-                if properties.get("sso_start_url").unwrap() == sso_start_url {
-                    profiles.push(SsoProfile::new(
-                        section.unwrap().to_owned(),
-                        properties.get("sso_start_url").unwrap().to_owned(),
-                        properties.get("sso_region").unwrap().to_owned(),
-                        properties.get("sso_account_id").unwrap().to_owned(),
-                        properties.get("sso_role_name").unwrap().to_owned(),
-                    ))
-                }
+    let mut profiles = Vec::new();
+    for (section, properties) in aws_conf.iter() {
+        let section_str = match section {
+            Some(s) => s,
+            None => continue,
+        };
+        // Skip new-format sections so a mixed config does not blow up here.
+        if section_str.starts_with("sso-session ") || section_str.starts_with("profile ") {
+            continue;
+        }
+        // Old-format profiles must have all four SSO keys inline.
+        if !properties.contains_key("sso_start_url")
+            || !properties.contains_key("sso_region")
+            || !properties.contains_key("sso_account_id")
+            || !properties.contains_key("sso_role_name")
+        {
+            continue;
+        }
+        if properties.get("sso_start_url").unwrap() != sso_start_url {
+            continue;
+        }
+        profiles.push(SsoProfile::new(
+            section_str.to_owned(),
+            properties.get("sso_start_url").unwrap().to_owned(),
+            properties.get("sso_region").unwrap().to_owned(),
+            properties.get("sso_account_id").unwrap().to_owned(),
+            properties.get("sso_role_name").unwrap().to_owned(),
+        ));
+    }
+    return profiles;
+}
+
+fn get_sso_profiles_new(session: &str, home: &String, filter_profile: Option<&str>) -> Vec<SsoProfile> {
+
+    let aws_conf = Ini::load_from_file(format!("{}{}", home, "/.aws/config")).unwrap();
+
+    let session_section = format!("sso-session {}", session);
+    let sso_start_url = aws_conf
+        .get_from(Some(session_section.as_str()), "sso_start_url")
+        .unwrap_or_else(|| panic!("[sso-session {}] not found or missing sso_start_url in ~/.aws/config", session))
+        .to_owned();
+    let sso_region = aws_conf
+        .get_from(Some(session_section.as_str()), "sso_region")
+        .unwrap().to_owned();
+
+    let mut profiles = Vec::new();
+    for (section, properties) in aws_conf.iter() {
+        let section_str = match section {
+            Some(s) => s,
+            None => continue,
+        };
+        if !section_str.starts_with("profile ") {
+            continue;
+        }
+        if properties.get("sso_session") != Some(session) {
+            continue;
+        }
+        let bare_name = section_str.trim_start_matches("profile ").to_owned();
+        if let Some(f) = filter_profile {
+            if bare_name != f {
+                continue;
             }
         }
-
-        return profiles;
+        profiles.push(SsoProfile::new(
+            bare_name,
+            sso_start_url.clone(),
+            sso_region.clone(),
+            properties.get("sso_account_id").unwrap().to_owned(),
+            properties.get("sso_role_name").unwrap().to_owned(),
+        ));
     }
 
+    if profiles.is_empty() {
+        match filter_profile {
+            Some(f) => panic!("No [profile {}] with sso_session = {} found in ~/.aws/config", f, session),
+            None => panic!("No [profile *] with sso_session = {} found in ~/.aws/config", session),
+        }
+    }
+
+    profiles
+}
+
+fn run_aws_sso_login(session: &str, verbose: bool) {
+    if verbose {
+        println!("Running: aws sso login --sso-session {}", session);
+    }
+    let status = Command::new("aws")
+        .args(&["sso", "login", "--sso-session", session])
+        .status()
+        .unwrap();
+    if !status.success() {
+        panic!("aws sso login --sso-session {} failed (exit {:?})", session, status.code());
+    }
+}
+
+fn read_sso_cache_token(start_url: &str, home: &str, verbose: bool) -> String {
+    let cache_dir = format!("{}/.aws/sso/cache", home);
+    let entries = fs::read_dir(&cache_dir)
+        .unwrap_or_else(|e| panic!("Could not read SSO cache dir {}: {}", cache_dir, e));
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let contents = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let token: SsoCacheToken = match serde_json::from_str(&contents) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if token.startUrl.as_deref() == Some(start_url) {
+            if let Some(at) = token.accessToken {
+                if verbose {
+                    println!("Using cached token from {:?} (expires {:?})", path, token.expiresAt);
+                }
+                return at;
+            }
+        }
+    }
+    panic!("No SSO cache token found for startUrl {} in {}", start_url, cache_dir);
 }
 
 fn register_client(oidc_url: &String, verbose: bool) -> RegisterClientResponse {
@@ -302,30 +417,49 @@ fn get_role_credentials(
     sso_url: &String,
     sso_account_id: &String,
     sso_role_name: &String,
-    create_token_resp: &CreateTokenResponse,
+    access_token: &str,
     verbose: bool,
-) -> GetRoleCredsResponse {
-    let get_role_creds = ureq::get(format!("{}{}", sso_url, "/federation/credentials").as_str())
+) -> Option<GetRoleCredsResponse> {
+    let resp = ureq::get(format!("{}{}", sso_url, "/federation/credentials").as_str())
         .query("account_id", sso_account_id)
         .query("role_name", sso_role_name)
         .set(
             "x-amz-sso_bearer_token",
-            format!("{}", create_token_resp.accessToken).as_str(),
+            access_token,
         )
-        .call()
-        .into_json_deserialize::<GetRoleCredsResponse>();
+        .call();
 
-    if verbose {
-        println!("{:#?}", get_role_creds);
+    if !resp.ok() {
+        let status = resp.status();
+        let body = resp.into_string().unwrap_or_else(|_| "<unreadable body>".to_owned());
+        eprintln!(
+            "Skipping {}:{} — SSO portal returned HTTP {}: {}",
+            sso_account_id, sso_role_name, status, body
+        );
+        return None;
     }
 
-    let get_role_creds_un = get_role_creds.unwrap();
+    let parsed = resp.into_json_deserialize::<GetRoleCredsResponse>();
 
     if verbose {
-        println!("{:#?}", get_role_creds_un);
+        println!("{:#?}", parsed);
     }
 
-    get_role_creds_un
+    match parsed {
+        Ok(v) => {
+            if verbose {
+                println!("{:#?}", v);
+            }
+            Some(v)
+        }
+        Err(e) => {
+            eprintln!(
+                "Skipping {}:{} — could not parse credentials response: {}",
+                sso_account_id, sso_role_name, e
+            );
+            None
+        }
+    }
 }
 
 fn save_sso(


### PR DESCRIPTION
This update handles  updates AWS made to the config file, but keeps functionality the same. Credentials still end up in `~/.aws/credentials` because there are some systems that still require this.

```
[sso-session xyz]
sso_region = eu-west-1
sso_start_url = https://xyz.awsapps.com/start/#/
sso_registration_scopes = sso:account:access

[profile xyz_123]
sso_session = xyz
sso_account_id = 001122334455
sso_role_name = DeveloperAccess
region = af-south-1
output = json
```

and old

```
[xyz_123]
sso_start_url = https://synlz.awsapps.com/start/#/
sso_region = eu-west-1
sso_account_id = 001122334455
sso_role_name = DeveloperAccess
region = af-south-1
output = json
```